### PR TITLE
[PHYSICS] Fixed issue with checking joint names in frc/trq sensors data

### DIFF
--- a/farms_mujoco/simulation/physics.py
+++ b/farms_mujoco/simulation/physics.py
@@ -267,13 +267,13 @@ def get_physics2data_maps(physics, sensor_data, sensor_maps):
     sensor_maps['force2data'] = np.array([
         row2index(row=forces_row, name=f'force_{joint_name}')
         for joint_name in joints_names
-        if joint_name in forces_row.names
+        if f"force_{joint_name}" in forces_row.names
     ])
     torques_row = physics.named.data.sensordata.axes.row
     sensor_maps['torque2data'] = np.array([
         row2index(row=torques_row, name=f'torque_{joint_name}')
         for joint_name in joints_names
-        if joint_name in forces_row.names
+        if f"torque_{joint_name}" in torques_row.names
     ])
 
     # Muscles - sensors


### PR DESCRIPTION
Issue: In the commit https://github.com/farmsim/farms_mujoco/commit/40727ebbd4c8223595d21bb1a06383205e7a1692#diff-2ac3f4b3b58684f46666e4f8b24b96472dc42a503d6d1720e3dab25b8324bdabR270 a check was introduced to enable logging for force/torque only if force/torque sensor is enabled. But the check never goes through since the joint_sensors are prefixed by joint_sensor type see: https://github.com/farmsim/farms_mujoco/blob/1095828b9febd3ece4955d14748e5f690751c723/farms_mujoco/simulation/mjcf.py#L988

Fix: Introduce appropriate prefix in checking the sensor name
```python
if f"force_{joint_name}" in forces_row.names
```

```python
if f"torque_{joint_name}" in torques_row.names
```