### PR TITLE
[MJCF] Use springref from morphology.joints for passive joints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ scripts/*test*
 *.hdf5
 *.log
 *.dot
+*.egg-info/*

--- a/farms_mujoco/simulation/mjcf.py
+++ b/farms_mujoco/simulation/mjcf.py
@@ -1622,6 +1622,7 @@ def setup_mjcf_xml(
                 namespace='joint',
                 identifier=f'{prefix}{joint_options.name}',
             )
+            joint.springref += joint_options.springref
             joint.stiffness += joint_options.stiffness*units.angular_stiffness
             joint.damping += joint_options.damping*units.angular_damping
             if _solreflimit := joint_options.extras.get('solreflimit'):


### PR DESCRIPTION
Use springref of passive joints from morphology.joints in mjcf model building.
This feature is used to transform joints equilibrium point from zero pose to resting/neutral pose of animals during simulation (e.g. raise necks).

To use:
Add a springref to a joint in morphology.joints. (The joint should also exist in control.motors with passive equations.)