### PR TITLE
[MJCF] Remove unique identifiers from texture.file for resuing xml fr…

### DIFF
--- a/farms_mujoco/simulation/mjcf.py
+++ b/farms_mujoco/simulation/mjcf.py
@@ -1224,6 +1224,12 @@ def mjcf2str(
         for mesh in mjcf_xml.find('asset').findall('mesh'):
             mjcf_mesh = mjcf_model.find('mesh', mesh.attrib['name'])
             mesh.attrib['file'] = mjcf_mesh.file.prefix + mjcf_mesh.file.extension
+            
+        for texture in mjcf_xml.find('asset').findall('texture'): 
+            if 'file' not in texture.attrib:
+                continue
+            mjcf_texture = mjcf_model.find('texture', texture.attrib['name'])
+            texture.attrib['file'] = mjcf_texture.file.prefix + mjcf_texture.file.extension
     # Convert to string
     xml_str = ET.tostring(
         mjcf_xml,


### PR DESCRIPTION
 Remove unique identifiers in texture:
Change
<texture name="a0_texture_link_body_00_composite" type="2d" file="link_body_00_composite-9e8ce00677d740bac61c4baed5a0d58cecef7f3e.png"/>
to
<texture name="a0_texture_link_body_00_composite" type="2d" file="link_body_00_composite-.png"/>
so that the output xml can be reloaded by mujoco.